### PR TITLE
Security: Python 3.14.3-slim, fix 9 CVEs, remove leaked PyPI token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ app/logs/*
 app/zvma10/__pycache__/*
 app/zvma9_7/__pycache__/*
 app/temp.sh
+app/.pypirc
+.pypirc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.14.3-slim
 
 EXPOSE 9999
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,9 +3,9 @@ annotated-types==0.6.0
 async-timeout==4.0.3
 backoff==2.2.1
 cachetools==5.3.1
-certifi==2023.7.22
+certifi>=2024.7.4
 charset-normalizer==3.3.0
-idna==3.4
+idna>=3.7
 monotonic==1.6
 prompt-toolkit==3.0.39
 pydantic>=2.9.0
@@ -13,9 +13,9 @@ Pygments==2.16.1
 python-dateutil==2.8.2
 pyvim==3.0.3
 pyvmomi==9.0.0.0
-requests==2.32.0
+requests>=2.32.4
 six==1.16.0
 tinydb==4.8.0
 typing_extensions>=4.12.2
-urllib3==2.0.6
+urllib3>=2.6.3
 wcwidth==0.2.8


### PR DESCRIPTION
## Summary

Follow-up to #67. Three changes that were added to that branch after it was merged.

- **Python 3.14.3-slim**: Bumps base image from `3.13-slim` to `3.14.3-slim` (released Feb 3 2026, current stable)
- **Fix 9 CVEs** found by Trivy filesystem scan:
  - `certifi` 2023.7.22 → `>=2024.7.4` — CVE-2024-39689 (LOW)
  - `idna` 3.4 → `>=3.7` — CVE-2024-3651 (MEDIUM, DoS via idna.encode())
  - `requests` 2.32.0 → `>=2.32.4` — CVE-2024-47081 (MEDIUM, .netrc credential leak)
  - `urllib3` 2.0.6 → `>=2.6.3` — 6 CVEs (3 HIGH decompression bomb, 3 MEDIUM redirect issues)
- **Remove `app/.pypirc`**: PyPI upload token was accidentally committed at `21f32e5` and has been in public history. File removed; `.pypirc` added to `.gitignore`.

> ⚠️ **Action required**: Rotate the PyPI token at https://pypi.org/manage/account/token/ — it remains in git history regardless of this PR.

## Test plan

- [ ] `docker compose build` succeeds on Python 3.14.3-slim
- [ ] `trivy fs --scanners vuln,secret .` reports 0 vulnerabilities and 0 secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)