### PR TITLE
Fix duplicate VRA metrics after VRA upgrade

### DIFF
--- a/app/python-node-exporter.py
+++ b/app/python-node-exporter.py
@@ -462,6 +462,12 @@ def GetVraMetrics(zvm_instance):
 
                 if vras_json is not None:
                     log.debug("VRA names: %s", vras_json)
+                    # Clear stale label sets so upgraded VRAs don't appear twice
+                    for g in (g_vra_memory, g_vra_vcpu_count, g_vra_protected_vms,
+                              g_vra_protected_vpgs, g_vra_protected_vols,
+                              g_vra_recovery_vms, g_vra_recovery_vpgs, g_vra_recovery_vols,
+                              g_vra_self_protected, g_vra_cpu_usage, g_vra_memory_usage):
+                        g.clear()
                     for vra in vras_json:
                         lbl = dict(
                             VraIdentifierStr=vra['VraIdentifierStr'],


### PR DESCRIPTION
## Summary
- Fixes issue #21: after a VRA is upgraded, its metrics appeared twice in Prometheus — once with the old `VraVersion` label and once with the new one
- Root cause: `VraVersion` is a Prometheus label; changing it creates a new time series while the old one persists until the exporter restarts
- Fix: call `.clear()` on all 11 VRA Gauges at the start of each collection cycle, removing stale label combinations before repopulating with current data

## Test plan
- [ ] Upgrade a VRA in the environment
- [ ] Verify the old version's metrics no longer appear after the next scrape cycle
- [ ] Verify the new version's metrics appear correctly with updated `VraVersion` label

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)