### PR TITLE
Add VmSourceVRA label and resolve VRA names for VM metrics (v3.1.0)

### DIFF
--- a/app/version.py
+++ b/app/version.py
@@ -1,5 +1,5 @@
 # version.py
-VERSION = "3.0.0"
+VERSION = "3.1.0"
 
 def main():
     # Put your main program code here


### PR DESCRIPTION
## Summary

- **New label `VmSourceVRA`** added to all `vm_*` metrics, populated from the VRA name on the protected/source side (e.g. `Z-VRA-192.168.50.21`)
- **`VmRecoveryVRA` improved** — previously emitted the raw ESXi host IP; now resolves to the actual VRA name using the same lookup
- Both labels are resolved each scrape cycle by building a `HostDisplayName → VraName` dict from a single `zvm.vras()` call before the VM loop
- Cloud-target VPGs (Azure, AWS) correctly emit `VmRecoveryVRA=""` since there is no local VRA on the recovery side
- Version bumped to **3.1.0**

## How it works

```python
# Built once per scrape cycle from zvm.vras()
host_to_vra = {v['HostDisplayName']: v['VraName'] for v in vras_for_lookup}

# Applied to every VM label set
VmSourceVRA  = host_to_vra.get(vm['OwningHostName'], '')   # protected-side VRA
VmRecoveryVRA = host_to_vra.get(vm['RecoveryHostName'], '') # recovery-side VRA
```

## Example metric output

Local-to-local VPG (both VRAs populated):
```
vm_actualrpo{VmName="ad1(1)",VmSourceVRA="Z-VRA-192.168.50.22",VmRecoveryVRA="Z-VRA-192.168.50.21",VpgName="local"} 5.0
```

Cloud VPG (recovery VRA empty):
```
vm_actualrpo{VmName="deepak-vm6",VmSourceVRA="Z-VRA-192.168.50.21",VmRecoveryVRA="",VpgName="cmh-azure-1"} 5.0
```

## Breaking change note

`VmRecoveryVRA` previously contained the raw ESXi host IP (e.g. `192.168.50.21`). It now contains the VRA name (e.g. `Z-VRA-192.168.50.21`). Any Grafana dashboards or Prometheus rules filtering on the old host IP format will need updating.

## Docker images published

- `recklessop/zerto-exporter:3.1.0`
- `recklessop/zerto-exporter:stable`
- `recklessop/zerto-exporter:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)